### PR TITLE
Add restart policy for elasticsearch container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 120
+    restart: on-failure
     networks:
       - reconcile-backend
 


### PR DESCRIPTION
reconcile depends on elastic and won't restart without. so we need to ensure elastic is running, eg. after server reboot.